### PR TITLE
Enhancement: Lock Beverage model when there are multiple queries to update the model

### DIFF
--- a/app/controllers/beverages_controller.rb
+++ b/app/controllers/beverages_controller.rb
@@ -4,9 +4,11 @@ class BeveragesController < ApplicationController
     end
 
     def update
-        beverage = Beverage.find(params[:id])
+        Beverage.transaction do
+        beverage = Beverage.lock.find(params[:id])
         beverage.update(beverage_params)
         render json: beverage.to_json(only: [:id, :name, :selected])
+        end
     end
 
     def selected

--- a/app/javascript/src/components/SelectMenu.jsx
+++ b/app/javascript/src/components/SelectMenu.jsx
@@ -100,10 +100,7 @@ export default function SelectMenu({ handleCloseModal }) {
                 selected: false
               });
             }
-            setTimeout(() => {
-              submitBeverage({ id: chefOption.beverage.id, selected: true });
-            }, 1000);
-            break;
+            submitBeverage({ id: chefOption.beverage.id, selected: true });
         }
 
         updateMenu(chefOption);


### PR DESCRIPTION
There was a problem when multiple queries asking for changing  beverage option, this is because of the one beverage restriction. First solution was Front -End sending a request after some milliseconds. 
Now, It is Back-End which is the responsible of this.